### PR TITLE
Fix typo, limitting -> limiting

### DIFF
--- a/lib/x_trace_web/controllers/trace_live.html.heex
+++ b/lib/x_trace_web/controllers/trace_live.html.heex
@@ -128,7 +128,7 @@
             <div class={["max-w-6xl mx-auto px-10 p-6 space-y-4", @tab != "max" && "hidden"]} id="max-tab">
               <div class="text-gray-500">
               The limit was also set using `{10,100}' instead of an integer, making the
-              rate-limitting at 10 messages per 100 milliseconds, instead of an absolute
+              rate-limiting at 10 messages per 100 milliseconds, instead of an absolute
               value.
               </div>
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`